### PR TITLE
add old release checks to GHA

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -26,9 +26,13 @@ jobs:
       matrix:
         config:
           - {os: windows-latest, r: 'release', rspm: "https://packagemanager.rstudio.com/all/latest"}
-          - {os: macOS-latest, r: 'release', rspm: "https://packagemanager.rstudio.com/all/latest"}
-          - {os: ubuntu-20.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: ubuntu-20.04, r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: windows-latest, r: '3.6',     rspm: "https://packagemanager.rstudio.com/cran/latest"}
+          - {os: macOS-latest,   r: 'release', rspm: "https://packagemanager.rstudio.com/all/latest"}
+          - {os: ubuntu-20.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: ubuntu-20.04,   r: 'devel',   rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: ubuntu-18.04,   r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
+          - {os: ubuntu-18.04,   r: '3.6',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
+          - {os: ubuntu-18.04,   r: '3.5',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true


### PR DESCRIPTION
kept ubuntu 18.04 because it's in the r-lib/actions repo like this
see https://github.com/r-lib/actions/blob/630f4c9d8b813f45d0327a2fc20eb264fd518450/examples/check-pak.yaml#L29-L37