### PR TITLE
Fix catpackages cuts

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -32,7 +32,6 @@ jobs:
           - {os: ubuntu-20.04,   r: 'devel',   rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
           - {os: ubuntu-18.04,   r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
           - {os: ubuntu-18.04,   r: '3.6',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
-          - {os: ubuntu-18.04,   r: '3.5',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nflreadr
 Title: Download 'nflverse' Data
-Version: 1.1.1.02
+Version: 1.1.1.03
 Authors@R: c(
     person("Tan", "Ho", , "tan@tanho.ca", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0001-8388-5155")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ License: MIT + file LICENSE
 URL: https://nflreadr.nflverse.com, https://github.com/nflverse/nflreadr
 BugReports: https://github.com/nflverse/nflreadr/issues
 Depends:
-    R (>= 3.5.0)
+    R (>= 3.6.0)
 Imports:
     cachem (>= 1.0.0),
     cli (>= 3.0.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## New Functions
 
 - `nflverse_sitrep()` and `ffverse_sitrep()` give a minimal overview of the package dependencies (v1.1.1.01)
+- `_sitrep()` fns receive a small print-related bugfix (v1.1.1.02)
 
 ---
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## New Functions
 
 - `nflverse_sitrep()` and `ffverse_sitrep()` give a minimal overview of the package dependencies (v1.1.1.01)
+- Minimum R version bumped to R 3.6.0 - this is the minimum version required to read the [current RDS file-version](https://stat.ethz.ch/R-manual/R-devel/library/base/html/readRDS.html). 
 - `_sitrep()` fns receive a small print-related bugfix (v1.1.1.02)
 
 ---

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 - `nflverse_sitrep()` and `ffverse_sitrep()` give a minimal overview of the package dependencies (v1.1.1.01)
 - Minimum R version bumped to R 3.6.0 - this is the minimum version required to read the [current RDS file-version](https://stat.ethz.ch/R-manual/R-devel/library/base/html/readRDS.html). 
-- `_sitrep()` fns receive a small print-related bugfix (v1.1.1.02)
+- `_sitrep()` fns receive a small print-related bugfix (v1.1.1.03)
 
 ---
 

--- a/R/sitrep.R
+++ b/R/sitrep.R
@@ -120,7 +120,7 @@ cat_packages <- function(packages,versions){
   l <- length(packages)
 
   breaks <- cut(x = seq_along(packages),
-                breaks = c(0, ceiling(l / 3), 2 * ceiling(l / 3), l))
+                breaks = c(0, ceiling(l / 3), 2 * ceiling(l / 3), l+1))
 
   p <- split(packages, breaks)
   v <- split(versions, breaks)


### PR DESCRIPTION
A bit of a lazy fix and causes four packages to be printed in 2x2 but whatever.

Also, bumping minimum R version to 3.6.0 - this is the minimum version required to read the latest RDS file format per https://stat.ethz.ch/R-manual/R-devel/library/base/html/readRDS.html 