### PR TITLE
improve test coverage

### DIFF
--- a/tests/testthat/test-from_url.R
+++ b/tests/testthat/test-from_url.R
@@ -67,6 +67,15 @@ test_that("download_local downloads files",{
     "No matching releases"
   )
 
+  expect_warning(
+    download_nflverse(
+      combine, "contracts",
+      folder_path = temp_dir,
+      file_type = "qs"
+    ),
+    regexp = "Please try another file type."
+  )
+
   download_nflverse(
     combine, "contracts",
     folder_path = temp_dir,
@@ -76,5 +85,4 @@ test_that("download_local downloads files",{
     length(list.files(temp_dir,recursive = TRUE)) >= 2
   )
 
-  unlink(temp_dir, recursive = TRUE)
 })

--- a/tests/testthat/test-nflverse.R
+++ b/tests/testthat/test-nflverse.R
@@ -269,5 +269,6 @@ test_that("load_contracts", {
   expect_s3_class(contracts, "tbl_df")
 
   expect_gt(nrow(contracts), 20000)
+  expect_message(print(contracts), regexp = "nflverse Historical Contract Data from OverTheCap.com|Data updated")
 })
 

--- a/tests/testthat/test-sitrep.R
+++ b/tests/testthat/test-sitrep.R
@@ -1,0 +1,5 @@
+test_that("sitrep works", {
+  expect_output(.sitrep("nflreadr"), regexp = "System Info|R version |Running under|nflreadr \\(|Dependencies")
+  expect_output(.sitrep("nflreadr", recursive = FALSE), regexp = "System Info|R version |Running under|nflreadr \\(")
+  expect_output(.sitrep("nflreadr", recursive = FALSE, header = "nflverse "), regexp = "System Info|R version |Running under|nflverse Packages|nflreadr \\(")
+})

--- a/tests/testthat/test-sitrep.R
+++ b/tests/testthat/test-sitrep.R
@@ -1,5 +1,5 @@
 test_that("sitrep works", {
-  expect_output(.sitrep("nflreadr"), regexp = "System Info|R version |Running under|nflreadr \\(|Dependencies")
+  skip_on_cran()
   expect_output(.sitrep("nflreadr", recursive = FALSE), regexp = "System Info|R version |Running under|nflreadr \\(")
-  expect_output(.sitrep("nflreadr", recursive = FALSE, header = "nflverse "), regexp = "System Info|R version |Running under|nflverse Packages|nflreadr \\(")
+  expect_output(nflverse_sitrep(pkg = "nflreadr"), regexp = "System Info|R version |Running under|nflverse Packages|nflreadr \\(|nflverse Dependencies")
 })


### PR DESCRIPTION
improve test coverage by

1. adding a test to downloader that results in missing filetype warning
2. testing print method
3. testing .sitrep

The .sitrep test failed because of the removed temporary directory in the tests of the downloader, so I removed that unlink line