### PR TITLE
prefer rds by default

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nflreadr
 Title: Download 'nflverse' Data
-Version: 1.2.0.07
+Version: 1.2.0.09
 Authors@R: c(
     person("Tan", "Ho", , "tan@tanho.ca", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0001-8388-5155")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 ## New data and functions
 
 - `load_contracts()` downloads (historical) player contracts from [OverTheCap.com](https://overthecap.com/contract-history/)
-- `download_local()` downloads all files attached to specified/all releases to a local folder. (v1.2.0.05) - requires dev version of piggyback atm.
+- `download_nflverse()` downloads all files attached to specified/all releases to a local folder. (v1.2.0.05) - requires dev version of piggyback atm.
 - `load_draft_picks()` now has the rest of the career stat fields from PFR (v1.2.0.07)
 
 ## fixes
@@ -13,7 +13,7 @@
 - bump minimum rlang version to 1.0.0
 - add piggyback suggested dependency
 - Export old class to support S4/DBI/`nflfastR::update_db()` as if it were a tibble. (v1.2.0.06)
-
+- `options(nflreadr.prefer)` defaults to rds now since qs is no longer a required dependency. (v1.2.0.09)
 
 ---
 

--- a/R/load_contracts.R
+++ b/R/load_contracts.R
@@ -20,7 +20,7 @@
 #' @seealso Issues with this data should be filed here: <https://github.com/nflverse/rotc>
 #'
 #' @export
-load_contracts <- function(file_type = getOption("nflreadr.prefer", default = "qs")){
+load_contracts <- function(file_type = getOption("nflreadr.prefer", default = "rds")){
   file_type <- rlang::arg_match0(file_type, c("rds", "qs", "parquet","csv"))
   loader <- choose_loader(file_type)
   url <- paste0("https://github.com/nflverse/nflverse-data/releases/download/",

--- a/R/load_nextgen_stats.R
+++ b/R/load_nextgen_stats.R
@@ -32,7 +32,7 @@
 #' @export
 load_nextgen_stats <- function(seasons = TRUE,
                                stat_type = c("passing", "receiving", "rushing"),
-                               file_type = getOption("nflreadr.prefer", default = "qs")){
+                               file_type = getOption("nflreadr.prefer", default = "rds")){
 
   if(!isTRUE(seasons)) {
     stopifnot(is.numeric(seasons),

--- a/R/load_pbp.R
+++ b/R/load_pbp.R
@@ -21,7 +21,7 @@
 #' @seealso Issues with this data should be filed here: <https://github.com/nflverse/nflfastR-data>
 #'
 #' @export
-load_pbp <- function(seasons = most_recent_season(), file_type = getOption("nflreadr.prefer", default = "qs")) {
+load_pbp <- function(seasons = most_recent_season(), file_type = getOption("nflreadr.prefer", default = "rds")) {
 
   file_type <- rlang::arg_match0(file_type, c("rds", "qs"))
   loader <- choose_loader(file_type)

--- a/R/load_player_stats.R
+++ b/R/load_player_stats.R
@@ -22,7 +22,7 @@
 #' @export
 load_player_stats <- function(seasons = most_recent_season(),
                               stat_type = c("offense","kicking"), # defense, punting, other as added
-                              file_type = getOption("nflreadr.prefer", default = "qs")){
+                              file_type = getOption("nflreadr.prefer", default = "rds")){
 
   if(!isTRUE(seasons)) {stopifnot(is.numeric(seasons),
                                   seasons >=1999,

--- a/man/load_contracts.Rd
+++ b/man/load_contracts.Rd
@@ -4,7 +4,7 @@
 \alias{load_contracts}
 \title{Load Historical Player Contracts from OverTheCap.com}
 \usage{
-load_contracts(file_type = getOption("nflreadr.prefer", default = "qs"))
+load_contracts(file_type = getOption("nflreadr.prefer", default = "rds"))
 }
 \arguments{
 \item{file_type}{One of \code{"rds"}, \code{"qs"}, \code{"csv"}, or \code{"parquet"}.

--- a/man/load_nextgen_stats.Rd
+++ b/man/load_nextgen_stats.Rd
@@ -7,7 +7,7 @@
 load_nextgen_stats(
   seasons = TRUE,
   stat_type = c("passing", "receiving", "rushing"),
-  file_type = getOption("nflreadr.prefer", default = "qs")
+  file_type = getOption("nflreadr.prefer", default = "rds")
 )
 }
 \arguments{

--- a/man/load_pbp.Rd
+++ b/man/load_pbp.Rd
@@ -6,7 +6,7 @@
 \usage{
 load_pbp(
   seasons = most_recent_season(),
-  file_type = getOption("nflreadr.prefer", default = "qs")
+  file_type = getOption("nflreadr.prefer", default = "rds")
 )
 }
 \arguments{

--- a/man/load_player_stats.Rd
+++ b/man/load_player_stats.Rd
@@ -7,7 +7,7 @@
 load_player_stats(
   seasons = most_recent_season(),
   stat_type = c("offense", "kicking"),
-  file_type = getOption("nflreadr.prefer", default = "qs")
+  file_type = getOption("nflreadr.prefer", default = "rds")
 )
 }
 \arguments{


### PR DESCRIPTION
Preferring qs causes check errors in minimal-dependency installation situations, e.g. https://github.com/ffverse/ffsimulator/runs/6425809609?check_suite_focus=true 