### PR TITLE
change oldest season with data to 2012 in load_snap_counts()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nflreadr
 Title: Download 'nflverse' Data
-Version: 1.3.0
+Version: 1.3.0.01
 Authors@R: c(
     person("Tan", "Ho", , "tan@tanho.ca", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0001-8388-5155")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# nflreadr (development version)
+
+## Bugfixes
+- `load_snap_counts()` now allows download of the 2012 season which was previously hardcoded from 2013 (#128)
+
+---
+
 # nflreadr 1.3.0
 
 This release introduces several new data functions, some new utilities, and an array of data/function updates. 

--- a/R/load_snap_counts.R
+++ b/R/load_snap_counts.R
@@ -25,9 +25,9 @@ load_snap_counts <- function(seasons = most_recent_season(),
                              file_type = getOption("nflreadr.prefer", default = "rds")){
 
   file_type <- rlang::arg_match0(file_type, c("rds", "csv", "parquet", "qs"))
-  if(isTRUE(seasons)) seasons <- 2013:most_recent_season()
+  if(isTRUE(seasons)) seasons <- 2012:most_recent_season()
   stopifnot(is.numeric(seasons),
-            seasons >= 2013,
+            seasons >= 2012,
             seasons <= most_recent_season())
 
   urls <- paste0("https://github.com/nflverse/nflverse-data/releases/",

--- a/R/load_snap_counts.R
+++ b/R/load_snap_counts.R
@@ -1,7 +1,7 @@
 #' Load Snap Counts from PFR
 #'
 #' @description Loads game level snap counts stats provided by Pro Football Reference
-#' starting with the 2013 season.
+#' starting with the 2012 season.
 #'
 #' @param seasons a numeric vector specifying what seasons to return, if `TRUE` returns all available data
 #' @param file_type One of `c("rds", "qs", "csv", "parquet")`. Can also be set globally with

--- a/man/load_snap_counts.Rd
+++ b/man/load_snap_counts.Rd
@@ -20,7 +20,7 @@ A tibble of game-level snap counts provided by Pro Football Reference.
 }
 \description{
 Loads game level snap counts stats provided by Pro Football Reference
-starting with the 2013 season.
+starting with the 2012 season.
 }
 \examples{
 \donttest{


### PR DESCRIPTION
Changed all instances of 2013 to 2012 in load_snap_counts(), to prevent 2012 data from being missed, despite being available

Resolves #128 