### PR TITLE
"indoors" is invalid

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nflreadr
 Title: Download 'nflverse' Data
-Version: 1.4.0.07
+Version: 1.4.0.08
 Authors@R: c(
     person("Tan", "Ho", , "tan@tanho.ca", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0001-8388-5155")),

--- a/R/load_schedules.R
+++ b/R/load_schedules.R
@@ -26,10 +26,10 @@ load_schedules <- function(seasons = TRUE){
                        nflverse = TRUE,
                        nflverse_type = "games and schedules")
   # nflfastR and nfl4th use the "roof" variable in several models
-  # These models expect one of c("indoors", "closed", "outdoors", "open", "retractable") or NA
+  # These models expect one of c("closed", "outdoors", "open", "retractable") or NA
   # We ran into problems where roof was empty or something else several time
   # So we catch these cases here and change invalid data to NA
-  valid_roof_values <- c("indoors", "closed", "dome", "outdoors", "open", "retractable", NA_character_)
+  valid_roof_values <- c("closed", "dome", "outdoors", "open", "retractable", NA_character_)
   out$roof[!out$roof %in% valid_roof_values] <- NA_character_
 
   return(out)

--- a/tests/testthat/test-nflverse.R
+++ b/tests/testthat/test-nflverse.R
@@ -69,7 +69,7 @@ test_that("load_schedules", {
 
   expect_gt(nrow(schedules), 6000)
 
-  valid_roof_values <- c("indoors", "closed", "dome", "outdoors", "open", "retractable", NA_character_)
+  valid_roof_values <- c("closed", "dome", "outdoors", "open", "retractable", NA_character_)
   expect_true(all(schedules$roof %in% valid_roof_values))
 
   expect_error(load_schedules("2020"))


### PR DESCRIPTION
In #218 I added a set of valid roof type values. I can't remember why I put "indoors" in there but it is actually invalid. This PR removes that value