### PR TITLE
redact paths with option names containing "directory"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nflreadr
 Title: Download 'nflverse' Data
-Version: 1.4.1.05
+Version: 1.4.1.06
 Authors@R: c(
     person("Tan", "Ho", , "tan@tanho.ca", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0001-8388-5155")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@ across all nflverse data. When printing to the console, nflreadr will convert ti
 - Added a dictionary to describe what each shorthand roster status indicates (#232)
 - `clean_team_abbrs()` now converts `"PHO"` to `"ARI"`. (#260)
 - Improved description of next score probability variables in `nflreadr::dictionary_pbp`. (#262) 
+- `.sitrep` and all `*_sitrep` functions now redact nflfastR option paths. (#263)
 
 ---
 

--- a/R/utils_sitrep.R
+++ b/R/utils_sitrep.R
@@ -145,7 +145,7 @@ ffverse_sitrep <- function(pkg = c("ffscrapr", "ffsimulator", "ffpros", "ffoppor
   pkg_search_string <- paste(packages, collapse = "|")
   package_options <- opts[grepl(pkg_search_string, x = names(opts))]
   if(redact_path) {
-    package_options[grepl("path|token|auth", names(package_options))] <- "{redacted, use redact_path = FALSE to show}"
+    package_options[grepl("path|token|auth|directory", names(package_options))] <- "{redacted, use redact_path = FALSE to show}"
   }
   return(package_options)
 }


### PR DESCRIPTION
`.sitrep` didn't redact nflfastR option paths stored in 

- `nflfastR.dbdirectory` and
- `nflfastR.raw_directory`