### PR TITLE
Allow depth-charts to load pre-season depth charts by changing `most_recent_season(roster = FALSE)` to `most_recent_season(roster = TRUE)`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nflreadr
 Title: Download 'nflverse' Data
-Version: 1.4.1.09
+Version: 1.4.1.10
 Authors@R: c(
     person("Tan", "Ho", , "tan@tanho.ca", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0001-8388-5155")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ across all nflverse data. When printing to the console, nflreadr will convert ti
 - `clean_team_abbrs()` now converts full team names like `"Los Angeles Chargers"` or team nicknames like `"Bills"` to corresponding team abbreviations (`"LAC"` and `"BUF"` in this example). (#269)
 - `load_players()` now loads v2 nflverse players data. This is a breaking change as some variables have been removed or renamed. Please see the [data comparison](https://github.com/nflverse/nflverse-players?tab=readme-ov-file#whats-new-in-players-v2) for more details.
 - `get_current_week()` now passes arguments on to `most_recent_season()`. (#272)
+- `load_depth_charts()` now provides preseason depth charts, and defaults to `most_recent_season(roster = TRUE)`, rather than `most_recent_season(roster = FALSE)`. (#)
 
 ---
 

--- a/R/load_depth_charts.R
+++ b/R/load_depth_charts.R
@@ -2,7 +2,7 @@
 #'
 #' @description Loads depth charts for each NFL team for each week back to 2001.
 #'
-#' @param seasons a numeric vector specifying what seasons to return, if `TRUE` returns all available data. Defaults to latest season.
+#' @param seasons a numeric vector specifying what seasons to return, if `TRUE` returns all available data. Defaults to latest season with available rosters.
 #' @param file_type One of `c("rds", "qs", "csv", "parquet")`. Can also be set globally with
 #' `options(nflreadr.prefer)`
 #'
@@ -20,14 +20,22 @@
 #'
 #' @return A tibble of week-level depth charts for each team.
 #' @export
-load_depth_charts <- function(seasons = most_recent_season(),
-                              file_type = getOption("nflreadr.prefer", default = "rds")){
-  if(isTRUE(seasons)) seasons <- 2001:most_recent_season()
-  stopifnot(is.numeric(seasons),
-            seasons >= 2001,
-            seasons <= most_recent_season())
+load_depth_charts <- function(
+  seasons = most_recent_season(roster = TRUE),
+  file_type = getOption("nflreadr.prefer", default = "rds")
+) {
+  if (isTRUE(seasons)) {
+    seasons <- 2001:most_recent_season(roster = TRUE)
+  }
+  stopifnot(
+    is.numeric(seasons),
+    seasons >= 2001,
+    seasons <= most_recent_season(roster = TRUE)
+  )
 
-  urls <- glue::glue("https://github.com/nflverse/nflverse-data/releases/download/depth_charts/depth_charts_{seasons}.rds")
+  urls <- glue::glue(
+    "https://github.com/nflverse/nflverse-data/releases/download/depth_charts/depth_charts_{seasons}.rds"
+  )
   out <- load_from_url(urls, seasons = seasons, nflverse = TRUE)
   return(out)
 }

--- a/man/load_depth_charts.Rd
+++ b/man/load_depth_charts.Rd
@@ -5,12 +5,12 @@
 \title{Load Weekly Depth Charts}
 \usage{
 load_depth_charts(
-  seasons = most_recent_season(),
+  seasons = most_recent_season(roster = TRUE),
   file_type = getOption("nflreadr.prefer", default = "rds")
 )
 }
 \arguments{
-\item{seasons}{a numeric vector specifying what seasons to return, if \code{TRUE} returns all available data. Defaults to latest season.}
+\item{seasons}{a numeric vector specifying what seasons to return, if \code{TRUE} returns all available data. Defaults to latest season with available rosters.}
 
 \item{file_type}{One of \code{c("rds", "qs", "csv", "parquet")}. Can also be set globally with
 \code{options(nflreadr.prefer)}}


### PR DESCRIPTION
To get preseason depth charts, we can now pass a valid year as long as we have rosters. 

Closes #274 

```r
nflreadr::load_depth_charts(2025) |>
   nrow()
#> [1] 38744
```