### PR TITLE
Redirect `load_teams()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nflreadr
 Title: Download 'nflverse' Data
-Version: 1.5.0
+Version: 1.5.0.9000
 Authors@R: c(
     person("Tan", "Ho", , "tan@tanho.ca", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0001-8388-5155")),
@@ -50,4 +50,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# nflreadr (development version)
+
+- `load_teams()` now accepts the argument `file_type` and respects the option `"nflreadr.prefer"`. 
+
 # nflreadr 1.5.0
 
 This release covers changes released before the start of the 2025 NFL season.

--- a/R/load_teams.R
+++ b/R/load_teams.R
@@ -4,6 +4,9 @@
 #'
 #' @param current If `TRUE` (the default), returns a standardized list of current teams only,
 #' with abbreviations as per [nflreadr::team_abbr_mapping].
+#' @param file_type One of `c("rds", "qs", "csv", "parquet")`. Can also be set globally with
+#' `options(nflreadr.prefer)`
+#'
 #' @examples
 #' \dontshow{.for_cran()}
 #' \donttest{
@@ -17,12 +20,19 @@
 #' @seealso Issues with this data should be filed here: <https://github.com/nflverse/nflverse-pbp>
 #'
 #' @export
-load_teams <- function(current = TRUE) {
-  out <- load_from_url(
-    "https://github.com/nflverse/nflverse-pbp/raw/master/teams_colors_logos.rds",
-    nflverse = TRUE,
-    nflverse_type = "team graphics"
+load_teams <- function(
+  current = TRUE,
+  file_type = getOption("nflreadr.prefer", default = "rds")
+) {
+  file_type <- rlang::arg_match0(file_type, c("rds", "qs", "csv", "parquet"))
+
+  urls <- paste0(
+    "https://github.com/nflverse/nflverse-data/releases/download/teams/",
+    "teams_colors_logos.",
+    file_type
   )
+
+  out <- load_from_url(urls, nflverse = TRUE)
 
   if (isTRUE(current)) {
     out <- out[out$team_abbr %in% nflreadr::team_abbr_mapping, ]

--- a/man/load_teams.Rd
+++ b/man/load_teams.Rd
@@ -4,11 +4,17 @@
 \alias{load_teams}
 \title{Load NFL Team Graphics, Colors, and Logos}
 \usage{
-load_teams(current = TRUE)
+load_teams(
+  current = TRUE,
+  file_type = getOption("nflreadr.prefer", default = "rds")
+)
 }
 \arguments{
 \item{current}{If \code{TRUE} (the default), returns a standardized list of current teams only,
 with abbreviations as per \link{team_abbr_mapping}.}
+
+\item{file_type}{One of \code{c("rds", "qs", "csv", "parquet")}. Can also be set globally with
+\code{options(nflreadr.prefer)}}
 }
 \value{
 A tibble of team-level image URLs and hex color codes.


### PR DESCRIPTION
`load_teams()` now accepts the `file_type` arg and loads data from the related nflverse-data release tag