### PR TITLE
`load_injuries()` handles data availability

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nflreadr
 Title: Download 'nflverse' Data
-Version: 1.5.0.9002
+Version: 1.5.0.9003
 Authors@R: c(
     person("Tan", "Ho", , "tan@tanho.ca", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0001-8388-5155")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 
 - `load_teams()` now accepts the argument `file_type` and respects the option `"nflreadr.prefer"`. 
 - `nflverse_releases()` and `nflverse_download()` now correctly work with tag names to find releases. (#296)
-- Stopped support of `file_type` "qs" and the deprecated the related function `qs_from_url()` because the underlying package qs has been removed from CRAN on 2026-01-17. Since the dependency is archived `qs_from_url()` will error. Please stop using it and make sure to change `option(nflreadr.prefer)` to one of "parquet", "rds", or "csv".
+- Stopped support of `file_type` "qs" and the deprecated the related function `qs_from_url()` because the underlying package qs has been removed from CRAN on 2026-01-17. Since the dependency is archived `qs_from_url()` will error. Please stop using it and make sure to change `option(nflreadr.prefer)` to one of "parquet", "rds", or "csv". (#303)
+- `load_injuries()` now errors on 2025+ seasons because our data source died after the 2024 season. Data from 2009 to 2024 will still remain available, though. (#304)
 
 # nflreadr 1.5.0
 

--- a/R/load_injuries.R
+++ b/R/load_injuries.R
@@ -1,8 +1,10 @@
-#' Load Injury Reports
+#' Load Injury Reports (2009-2024)
 #'
 #' Data collected from an API for weekly injury report data.
+#' Data source died after the 2024 season.
 #'
-#' @param seasons a numeric vector of seasons to return, data available since 2009. Defaults to latest season available.
+#' @param seasons a numeric vector of seasons to return, data available since 2009.
+#'  Defaults to latest season available (2024).
 #' @param file_type One of `c("rds", "csv", "parquet")`. Can also be set globally with
 #' `options(nflreadr.prefer)`
 #'
@@ -10,7 +12,7 @@
 #' \dontshow{.for_cran()}
 #' \donttest{
 #' try({# prevents cran errors
-#'     load_injuries(2020)
+#'   load_injuries(2020)
 #' })
 #' }
 #'
@@ -22,18 +24,18 @@
 #'
 #' @export
 load_injuries <- function(
-  seasons = most_recent_season(),
-  file_type = getOption("nflreadr.prefer", default = "rds")
+    seasons = 2024L,
+    file_type = getOption("nflreadr.prefer", default = "rds")
 ) {
   if (isTRUE(seasons)) {
-    seasons <- 2009:nflreadr::most_recent_season()
+    seasons <- 2009:2024
   }
 
   file_type <- rlang::arg_match0(file_type, c("rds", "csv", "parquet"))
   stopifnot(
-    is.numeric(seasons),
-    seasons >= 2009,
-    seasons <= most_recent_season()
+    "seasons must be numeric" = is.numeric(seasons),
+    "Injury data availability starts 2009" = seasons >= 2009,
+    "Data source died after the 2024 season" = seasons <= 2024
   )
 
   urls <- glue::glue(

--- a/man/load_injuries.Rd
+++ b/man/load_injuries.Rd
@@ -2,15 +2,16 @@
 % Please edit documentation in R/load_injuries.R
 \name{load_injuries}
 \alias{load_injuries}
-\title{Load Injury Reports}
+\title{Load Injury Reports (2009-2024)}
 \usage{
 load_injuries(
-  seasons = most_recent_season(),
+  seasons = 2024L,
   file_type = getOption("nflreadr.prefer", default = "rds")
 )
 }
 \arguments{
-\item{seasons}{a numeric vector of seasons to return, data available since 2009. Defaults to latest season available.}
+\item{seasons}{a numeric vector of seasons to return, data available since 2009.
+Defaults to latest season available (2024).}
 
 \item{file_type}{One of \code{c("rds", "csv", "parquet")}. Can also be set globally with
 \code{options(nflreadr.prefer)}}
@@ -20,12 +21,13 @@ a tibble of season-level injury report data.
 }
 \description{
 Data collected from an API for weekly injury report data.
+Data source died after the 2024 season.
 }
 \examples{
 \dontshow{.for_cran()}
 \donttest{
 try({# prevents cran errors
-    load_injuries(2020)
+  load_injuries(2020)
 })
 }
 

--- a/tests/testthat/test-nflverse.R
+++ b/tests/testthat/test-nflverse.R
@@ -190,6 +190,12 @@ test_that("load_injuries", {
   # no injury data 2025+
   injuries_all <- load_injuries(seasons = 2009:2024)
 
+  # error on invalid seasons
+  expect_error(load_injuries(2008))
+  expect_error(load_injuries(2025))
+  # error on character input
+  expect_error(load_injuries("2010"))
+
   expect_s3_class(injuries, "nflverse_data")
   expect_s3_class(injuries_years, "nflverse_data")
   expect_s3_class(injuries_all, "nflverse_data")

--- a/tests/testthat/test-nflverse.R
+++ b/tests/testthat/test-nflverse.R
@@ -187,8 +187,7 @@ test_that("load_injuries", {
 
   injuries <- load_injuries()
   injuries_years <- load_injuries(seasons = 2019:2020)
-  # no injury data 2025+
-  injuries_all <- load_injuries(seasons = 2009:2024)
+  injuries_all <- load_injuries(seasons = TRUE)
 
   # error on invalid seasons
   expect_error(load_injuries(2008))


### PR DESCRIPTION
closes #287

`load_injuries()` now

- translates `seasons = TRUE` to the valid range of 2009:2024 seasons
- catches seasons outside the valid season range
- communicates data availability in docs (2009 - 2024)

NOTE: I use named arguments in `stopifnot` here as I think it was introduced in R4.0 and we can start doing this now