### PR TITLE
New season on Wednesday

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nflreadr
 Title: Download 'nflverse' Data
-Version: 1.5.0.9002
+Version: 1.5.0.9003
 Authors@R: c(
     person("Tan", "Ho", , "tan@tanho.ca", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0001-8388-5155")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 
 - `load_teams()` now accepts the argument `file_type` and respects the option `"nflreadr.prefer"`. 
 - `nflverse_releases()` and `nflverse_download()` now correctly work with tag names to find releases. (#296)
-- Stopped support of `file_type` "qs" and the deprecated the related function `qs_from_url()` because the underlying package qs has been removed from CRAN on 2026-01-17. Since the dependency is archived `qs_from_url()` will error. Please stop using it and make sure to change `option(nflreadr.prefer)` to one of "parquet", "rds", or "csv".
+- Stopped support of `file_type` "qs" and the deprecated the related function `qs_from_url()` because the underlying package qs has been removed from CRAN on 2026-01-17. Since the dependency is archived `qs_from_url()` will error. Please stop using it and make sure to change `option(nflreadr.prefer)` to one of "parquet", "rds", or "csv". (#303)
+- `most_recent_season()` (and its aliases `get_latest_season()` and `get_current_season()`) now flip the switch to the new season on Wednesday following Labor Day (used to be Thursday) as NFL announced that the 2026 season will kick off on Wednesday because the TNF game will be played in Australia. (#307)
 
 # nflreadr 1.5.0
 

--- a/R/utils_date.R
+++ b/R/utils_date.R
@@ -1,11 +1,17 @@
 #' Get Latest Season
 #'
-#' A helper function to choose the most recent season available for a given dataset
+#' A helper function to choose the most recent season available for a given dataset.
+#'
+#' This used to return new season on Thursday following Labor Day but NFL
+#' announced in March 2026 that the 2026 season will kick off on
+#' Wednesday because the TNF game will be played in Australia. We expect this
+#' to happen in future seasons as well and decided to flip the switch on
+#' Wednesday going forward.
 #'
 #' @param roster Either `TRUE` or `FALSE`.
 #' If `TRUE`, will return current year after March 15th, otherwise previous year.
-#' If `FALSE`, will return current year on or after Thursday following Labor Day,
-#' i.e. Thursday after the first Monday in September. Otherwise previous year.
+#' If `FALSE`, will return current year on or after Wednesday following Labor Day,
+#' i.e. Wednesday after the first Monday in September. Otherwise previous year.
 #'
 #' @rdname latest_season
 #' @return most recent season (a four digit numeric)
@@ -18,8 +24,8 @@ most_recent_season <- function(roster = FALSE) {
   current_day <- as.integer(format(today, format = "%d"))
   # First Monday of September
   labor_day <- compute_labor_day(current_year)
-  # Thursday following Labor Day is TNF season opener
-  season_opener <- labor_day + 3
+  # Wednesday following Labor Day is season opener (starting in 2026)
+  season_opener <- labor_day + 2
 
   if (
     (isFALSE(roster) && today >= season_opener) ||

--- a/man/latest_season.Rd
+++ b/man/latest_season.Rd
@@ -15,14 +15,21 @@ get_current_season(roster = FALSE)
 \arguments{
 \item{roster}{Either \code{TRUE} or \code{FALSE}.
 If \code{TRUE}, will return current year after March 15th, otherwise previous year.
-If \code{FALSE}, will return current year on or after Thursday following Labor Day,
-i.e. Thursday after the first Monday in September. Otherwise previous year.}
+If \code{FALSE}, will return current year on or after Wednesday following Labor Day,
+i.e. Wednesday after the first Monday in September. Otherwise previous year.}
 }
 \value{
 most recent season (a four digit numeric)
 }
 \description{
-A helper function to choose the most recent season available for a given dataset
+A helper function to choose the most recent season available for a given dataset.
+}
+\details{
+This used to return new season on Thursday following Labor Day but NFL
+announced in March 2026 that the 2026 season will kick off on
+Wednesday because the TNF game will be played in Australia. We expect this
+to happen in future seasons as well and decided to flip the switch on
+Wednesday going forward.
 }
 \seealso{
 Other Date utils: 


### PR DESCRIPTION
closes #306 

`most_recent_season()` (and aliases) used to return new season on Thursday following Labor Day but NFL announced in March 2026 that the 2026 season will kick off on Wednesday because the TNF game will be played in Australia. We expect this to happen in future seasons as well and decided to flip the switch on Wednesday going forward.