### PR TITLE
Allow upcoming season as well

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nflreadr
 Title: Download 'nflverse' Data
-Version: 1.5.1.9001
+Version: 1.5.1.9002
 Authors@R: c(
     person("Tan", "Ho", , "tan@tanho.ca", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0001-8388-5155")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 - `clean_team_abbrs` now converts `"AZ"` to `"ARI"`. (#312)
 - Refreshed the `load_contracts()` data dictionary to cover the current columns, including the nested `season_history` and `contract_history` data frames.
 - Added the missing `n_defense_box` column and expanded the `read_thrown` value definitions in the `load_ftn_charting()` data dictionary. (#216)
+- `load_injuries()` no longer rejects an upcoming season during the practice week before the season opener. (#320)
 
 # nflreadr 1.5.1
 

--- a/R/load_injuries.R
+++ b/R/load_injuries.R
@@ -33,7 +33,7 @@ load_injuries <- function(
   stopifnot(
     is.numeric(seasons),
     seasons >= 2009,
-    seasons <= most_recent_season()
+    seasons <= most_recent_season(roster = TRUE)
   )
 
   urls <- glue::glue(


### PR DESCRIPTION
`load_injuries()` currently rejects seasons > `most_recent_season(roster = FALSE)` which means we can't download injury reports until the day of the season opener. To avoid this issue, we allow upcoming season as well.