### PR TITLE
Fix missing contract draft fields from player data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 - `clean_team_abbrs` now converts `"AZ"` to `"ARI"`. (#312)
 - Refreshed the `load_contracts()` data dictionary to cover the current columns, including the nested `season_history` and `contract_history` data frames.
+- `load_contracts()` now fills missing draft fields from `load_players()` when the contracts data has a matching OTC player ID. (#316)
 - Added the missing `n_defense_box` column and expanded the `read_thrown` value definitions in the `load_ftn_charting()` data dictionary. (#216)
 - `load_injuries()` no longer rejects an upcoming season during the practice week before the season opener. (#320)
 

--- a/R/load_contracts.R
+++ b/R/load_contracts.R
@@ -29,5 +29,65 @@ load_contracts <- function(
     "https://github.com/nflverse/nflverse-data/releases/download/contracts/historical_contracts.{file_type}"
   )
   out <- load_from_url(url, nflverse = TRUE)
+  if (anyNA(out$draft_year)) {
+    out <- fill_contract_draft_info(out, load_players(file_type = file_type))
+  }
   return(out)
+}
+
+fill_contract_draft_info <- function(contracts, players) {
+  out <- data.table::copy(contracts)
+  out_attrs <- attributes(out)
+  player_draft <- data.table::copy(data.table::as.data.table(players))
+  needed_contract_cols <- c(
+    "otc_id", "draft_year", "draft_round", "draft_overall", "draft_team"
+  )
+  needed_player_cols <- c(
+    "otc_id", "draft_year", "draft_round", "draft_pick", "draft_team"
+  )
+  if (
+    !all(needed_contract_cols %in% names(out)) ||
+      !all(needed_player_cols %in% names(player_draft))
+  ) {
+    return(out)
+  }
+
+  data.table::setDT(out)
+  player_draft <- data.table::data.table(
+    otc_id = suppressWarnings(as.integer(player_draft[["otc_id"]])),
+    player_draft_year = player_draft[["draft_year"]],
+    player_draft_round = player_draft[["draft_round"]],
+    player_draft_overall = player_draft[["draft_pick"]],
+    player_draft_team = player_draft[["draft_team"]]
+  )
+  player_draft <- player_draft[
+    !is.na(player_draft[["otc_id"]]) &
+      (!is.na(player_draft[["player_draft_year"]]) |
+        !is.na(player_draft[["player_draft_round"]]) |
+        !is.na(player_draft[["player_draft_overall"]]) |
+        !is.na(player_draft[["player_draft_team"]]))
+  ]
+  player_draft <- unique(player_draft, by = "otc_id")
+
+  draft_match <- match(out[["otc_id"]], player_draft[["otc_id"]])
+  draft_fields <- list(
+    draft_year = "player_draft_year",
+    draft_round = "player_draft_round",
+    draft_overall = "player_draft_overall",
+    draft_team = "player_draft_team"
+  )
+  for (contract_field in names(draft_fields)) {
+    replacement <- out[[contract_field]]
+    player_values <- player_draft[[draft_fields[[contract_field]]]][draft_match]
+    replacement <- replacement %c% player_values
+    data.table::set(out, j = contract_field, value = replacement)
+  }
+  data.table::setattr(out, "class", out_attrs$class)
+  for (attr_name in setdiff(
+    names(out_attrs),
+    c("names", "row.names", "class", ".internal.selfref")
+  )) {
+    data.table::setattr(out, attr_name, out_attrs[[attr_name]])
+  }
+  out
 }

--- a/tests/testthat/test-load_contracts.R
+++ b/tests/testthat/test-load_contracts.R
@@ -1,0 +1,50 @@
+test_that("contract draft fields are filled from player data by OTC ID", {
+  contracts <- data.frame(
+    player = c("Kevin Kolb", "Existing Draft", "No Player Match"),
+    otc_id = c(2117L, 1L, 2L),
+    draft_year = c(NA_integer_, 2020L, NA_integer_),
+    draft_round = c(NA_integer_, 3L, NA_integer_),
+    draft_overall = c(NA_integer_, 70L, NA_integer_),
+    draft_team = c(NA_character_, "OLD", NA_character_)
+  )
+
+  contracts <- as.nflverse_data(
+    contracts,
+    nflverse_type = "Historical Contract Data from OverTheCap.com"
+  )
+
+  players <- data.frame(
+    display_name = c("Kevin Kolb", "Existing Draft", "Bad ID"),
+    otc_id = c("2117", "1", "not-an-id"),
+    draft_year = c(2007L, 2021L, 2000L),
+    draft_round = c(2L, 1L, 4L),
+    draft_pick = c(36L, 1L, 100L),
+    draft_team = c("PHI", "NEW", "BAD")
+  )
+
+  out <- nflreadr:::fill_contract_draft_info(contracts, players)
+
+  expect_s3_class(out, "nflverse_data")
+  expect_equal(out$draft_year, c(2007L, 2020L, NA_integer_))
+  expect_equal(out$draft_round, c(2L, 3L, NA_integer_))
+  expect_equal(out$draft_overall, c(36L, 70L, NA_integer_))
+  expect_equal(out$draft_team, c("PHI", "OLD", NA_character_))
+})
+
+test_that("contract draft filling is a no-op without player draft fields", {
+  contracts <- as.nflverse_data(
+    data.frame(
+      otc_id = 1L,
+      draft_year = NA_integer_,
+      draft_round = NA_integer_,
+      draft_overall = NA_integer_,
+      draft_team = NA_character_
+    ),
+    nflverse_type = "Historical Contract Data from OverTheCap.com"
+  )
+
+  out <- nflreadr:::fill_contract_draft_info(contracts, data.frame())
+
+  expect_s3_class(out, "nflverse_data")
+  expect_equal(out$draft_year, NA_integer_)
+})


### PR DESCRIPTION
## Summary
Fill missing draft fields in `load_contracts()` from `load_players()` when the contracts row has a matching OTC player ID.

## Thanks to maintainers
Thanks for maintaining `nflreadr` and for the concrete suggestion in #316 about using players data for this gap.

## Issue or motivation
Fixes #316. Some OverTheCap contract rows have `draft_year`, `draft_round`, `draft_overall`, and `draft_team` missing even though nflverse players data already has those values for the same OTC ID.

## Root cause
`load_contracts()` returned the historical contracts file as-is. When OTC omitted draft metadata for a player, the loader did not reconcile those fields with the players dataset.

## Change
Add an internal `fill_contract_draft_info()` helper that matches contracts to players by integer OTC ID, maps player `draft_pick` to contract `draft_overall`, fills only missing contract draft fields, and preserves the existing `nflverse_data` class/metadata.

## Tests
- `testthat::test_file("tests/testthat/test-load_contracts.R")`: 7 passed, 0 failed, 0 skipped.
- Live-data smoke: current contracts missing `draft_year` fell from 330 rows to 280 rows; Kevin Kolb (`otc_id = 2117`) now returns 2007 / 2 / 36 / PHI.
- `git diff --check`: passed.
- `R CMD build --no-manual .`: passed on a clean source export.
- `R CMD check --no-manual nflreadr_1.5.1.9002.tar.gz`: `Status: OK`.
- `pkgdown::check_pkgdown()`: passed.
- `covr::package_coverage(...)`: passed (`nflreadr Coverage: 24.11%`).

## Scope
This only fills missing contract draft fields when `load_players()` has a matching OTC ID. It does not change the source contracts or players data, the contracts schema, non-draft columns, cache behavior, file-type support, or unmatched players.
